### PR TITLE
Update Streamlink Plugin to Use WebView Instead of Cloudscraper

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,15 +7,18 @@ A Simple [Kick.com](https://kick.com) plugin for [Streamlink](https://github.com
   * For Windows users with Streamlink builds which come bundled with an embedded Python environment, regular pip will not suffice and a ModuleNotFoundError will be raised when running Streamlink. You can fix this by adding `--target=<StreamLinkInstallPath>\pkgs`
 * Copy the [kick.py](kick.py) file into one of the [sideload directories](https://streamlink.github.io/cli/plugin-sideloading.html)
 
+
 ## Usage
+```
 streamlink kick.com/trainwreckstv best
 streamlink kick.com/video/c32a463d-4f4e-44f8-a5f3-88e8c5c8e720 best
 streamlink kick.com/trainwreckstv?clip=clip_01H6V5QHN7VMYHKNYVY7B6FRWW best
+```
 
 ---
 **TIP**
 
-You can passthrough the stream feed to your player using the [`--player-passthrough TYPES`](https://streamlink.github.io/cli.html#cmdoption-player-passthrough) option
+You can passthrough the stream feed to your player using the [```--player-passthrough TYPES```](https://streamlink.github.io/cli.html#cmdoption-player-passthrough) option
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -1,24 +1,22 @@
 # Streamlink Kick plugin
 
-A Simple [Kick.com](https://kick.com) plugin for [Streamlink](https://github.com/streamlink/streamlink). This plugin uses an extra dependency [cloudscraper](https://github.com/VeNoMouS/cloudscraper) in order to try to access KICK's cloudflare protected public API, until KICK provides a more streamlined way to do so.
+A Simple [Kick.com](https://kick.com) plugin for [Streamlink](https://github.com/streamlink/streamlink). This plugin uses an extra dependency [webview](https://github.com/r0x0r/pywebview) in order to try to access KICK's Cloudflare protected public API, until KICK provides a more streamlined way to do so.
 
 ## Install
-* pip install [cloudscraper](https://pypi.org/project/cloudscraper)
-  * For Windows users with streamlink builds which come bundled with an embedded Python environment, regular pip will not suffice and a ModuleNotFoundError will be raised when running streamlink. You can fix this by adding ```--target=<StreamLinkInstallPath>\pkgs```
-* Copy the [kick.py](kick.py) file into one of the the [sideload directories](https://streamlink.github.io/cli/plugin-sideloading.html)
-
+* pip install [pywebview](https://pypi.org/project/pywebview/)
+  * For Windows users with Streamlink builds which come bundled with an embedded Python environment, regular pip will not suffice and a ModuleNotFoundError will be raised when running Streamlink. You can fix this by adding `--target=<StreamLinkInstallPath>\pkgs`
+* Copy the [kick.py](kick.py) file into one of the [sideload directories](https://streamlink.github.io/cli/plugin-sideloading.html)
 
 ## Usage
-```
 streamlink kick.com/trainwreckstv best
 streamlink kick.com/video/c32a463d-4f4e-44f8-a5f3-88e8c5c8e720 best
 streamlink kick.com/trainwreckstv?clip=clip_01H6V5QHN7VMYHKNYVY7B6FRWW best
-```
 
 ---
 **TIP**
 
-You can passthrough the stream feed to your player using the [```--player-passthrough TYPES```](https://streamlink.github.io/cli.html#cmdoption-player-passthrough) option
+You can passthrough the stream feed to your player using the [`--player-passthrough TYPES`](https://streamlink.github.io/cli.html#cmdoption-player-passthrough) option
 
 ---
+
 


### PR DESCRIPTION
Hi,

This PR updates the Streamlink plugin to use WebView instead of Cloudscraper, ensuring it works with the latest Cloudflare protections.

Changes:

- Replaced Cloudscraper with WebView.
- Users may be required to complete a manual Cloudflare verification.